### PR TITLE
Initial implementation of the applipress processor multithreading

### DIFF
--- a/create_doc/cli.py
+++ b/create_doc/cli.py
@@ -67,6 +67,7 @@ def init():
                 "file_extensions": [".html"],
                 "from_form": "",
                 "to_form": "",
+                "thread_count": 1,
                 "gpt_model_id": "gpt-3.5-turbo",
                 "gpt_model_token_limit": 4096,
                 "gpt_prompts": [
@@ -238,7 +239,7 @@ def applipress_process_processor(processor, config):
                           processor['angular_skip_html_router_outlet'], processor['angular_router_outlet_message'],
                           processor['content_title'], processor['file_extensions'],
                           processor['add_dependency_links'], processor['add_file_path'],
-                          processor['dependency_link_text'])
+                          processor['dependency_link_text'], processor['thread_count'])
 
 @cli.command()
 @click.argument('processor_name', type=str, default='all')


### PR DESCRIPTION
Applipress processor can now utilize multithreading to generate documentation much faster.
Keep in mind that these "threads" aren't the physical CPU threads, which means that you can set the "thread_count" field in "create_doc.json" to virtually any number you want as long as the program doesn't crash.
"thread_count" field represents the number of processes that will be spawned concurrently.